### PR TITLE
Update the URL for the pure javascript implementation, added a Dockerfile & fixed just a pure port not working 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+
+COPY src/go.mod src/go.sum ./
+RUN go mod download
+
+COPY src/* .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+    -ldflags="-s -w -X main.version=${VERSION}" -o /out/comma .
+
+FROM alpine:3.20
+RUN mkdir /data && adduser -D -u 10001 app && chown app:app /data
+
+COPY --from=build /out/comma /usr/local/bin/comma
+
+USER app
+
+EXPOSE 9991
+
+ENTRYPOINT ["comma", "/data", "9991"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY src/* .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
-    -ldflags="-s -w -X main.version=${VERSION}" -o /out/comma .
+    -ldflags="-s -w" -o /out/comma .
 
 FROM alpine:3.20
 RUN mkdir /data && adduser -D -u 10001 app && chown app:app /data

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Integrating this in your website takes less than 100 lines of javascript.
 You can either:
 
 * use jquery, like [on my old blog](https://github.com/Dieterbe/hugo-theme-blog/blob/master/layouts/partials/comments.html)
-* use pure javascript, like [on my new blog](https://github.com/Dieterbe/dieterblog/blob/master/layouts/partials/comments.html)
+* use pure javascript, like [on my new blog](https://github.com/Dieterbe/dieterblog/blob/master/layouts/_partials/comments.html)
 
 
 See it in action on [dieter.plaetinck.be](http://dieter.plaetinck.be/)

--- a/src/main.go
+++ b/src/main.go
@@ -26,6 +26,11 @@ func main() {
 	path = strings.TrimSuffix(os.Args[1], "/")
 
 	addr = os.Args[2]
+
+	if !strings.Contains(addr, ":") {
+		addr = ":" + addr
+	}
+
 	fmt.Println("looking for comments in", path)
 	fmt.Println("will listen for http traffic on", addr)
 	if len(os.Args) == 4 {
@@ -44,7 +49,10 @@ func main() {
 		),
 	),
 	)
-	http.ListenAndServe(addr, nil)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		fmt.Fprintln(os.Stderr, "server error:", err)
+		os.Exit(1)
+	}
 }
 
 func handlePost(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This pull request is small, just wanted to use this for my own site but I deploy my things using docker.

While working on docker I noticed that a pure port doesn't work, (i.e ./comma /data 9991), so I added in a check for that.

I do believe though that this may benefit from maybe having a github actions workflow to automatically build and push the code to a container image on tagged releases? I have some working examples already but I do not want to push that on you without you being good with it.

Then I wanted to check your implementation for comments, but also noticed that the link is dead, just replaced with a prefixed underscore.

That should be all, let me know if this needs any changes.